### PR TITLE
Change default auto_field to autofield

### DIFF
--- a/feincms3_sites/apps.py
+++ b/feincms3_sites/apps.py
@@ -4,5 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class SitesAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    
     name = "feincms3_sites"
     verbose_name = capfirst(_("sites"))


### PR DESCRIPTION
Since Django 3.2 the default is BigAutoField. Without this patch it generates a migration in the installed package.